### PR TITLE
security: resolve CodeQL findings

### DIFF
--- a/apps/server/src/auth/setup-token.ts
+++ b/apps/server/src/auth/setup-token.ts
@@ -1,6 +1,7 @@
 import {
-  chmodSync,
-  existsSync,
+  closeSync,
+  fchmodSync,
+  openSync,
   readFileSync,
   unlinkSync,
   writeFileSync,
@@ -21,33 +22,23 @@ export function initializeSetupToken(setupComplete: boolean) {
     return;
   }
 
-  const setupTokenFileExists = existsSync(paths.setupToken);
-  if (setupTokenFileExists) setPrivateFileMode(paths.setupToken);
-
   if (config.setupToken) {
     activeToken = config.setupToken;
     return;
   }
 
-  if (setupTokenFileExists) {
-    const existing = readFileSync(paths.setupToken, "utf8").trim();
-    if (existing.length < 16) {
-      throw new Error(
-        `Setup token at ${paths.setupToken} is invalid. Remove it to generate a new token.`,
-      );
-    }
-    activeToken = existing;
+  const generated = randomBytes(32).toString("base64url");
+  if (createSetupTokenFile(generated)) {
+    activeToken = generated;
+    setupLogger.warn(`SteamBee setup token: ${generated}`);
     return;
   }
 
-  const generated = randomBytes(32).toString("base64url");
-  writeFileSync(paths.setupToken, `${generated}\n`, {
-    mode: 0o600,
-    flag: "wx",
-  });
-  setPrivateFileMode(paths.setupToken);
-  activeToken = generated;
-  setupLogger.warn(`SteamBee setup token: ${generated}`);
+  const existing = readSetupTokenFile();
+  if (!existing) {
+    throw new Error("Setup token file disappeared before it could be read.");
+  }
+  activeToken = existing;
 }
 
 export function assertSetupToken(candidate: string) {
@@ -70,12 +61,60 @@ export function isSetupTokenRequired() {
 }
 
 function removeSetupTokenFile() {
-  if (!existsSync(paths.setupToken)) return;
-  unlinkSync(paths.setupToken);
+  try {
+    unlinkSync(paths.setupToken);
+  } catch (error) {
+    if (!isFileError(error, "ENOENT")) throw error;
+  }
 }
 
-function setPrivateFileMode(path: string) {
-  if (process.platform !== "win32") chmodSync(path, 0o600);
+function readSetupTokenFile() {
+  let descriptor: number;
+  try {
+    descriptor = openSync(paths.setupToken, "r");
+  } catch (error) {
+    if (isFileError(error, "ENOENT")) return null;
+    throw error;
+  }
+
+  try {
+    setPrivateDescriptorMode(descriptor);
+    const token = readFileSync(descriptor, "utf8").trim();
+    if (token.length < 16) {
+      throw new Error(
+        `Setup token at ${paths.setupToken} is invalid. Remove it to generate a new token.`,
+      );
+    }
+    return token;
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function createSetupTokenFile(token: string) {
+  let descriptor: number;
+  try {
+    descriptor = openSync(paths.setupToken, "wx", 0o600);
+  } catch (error) {
+    if (isFileError(error, "EEXIST")) return false;
+    throw error;
+  }
+
+  try {
+    writeFileSync(descriptor, `${token}\n`, "utf8");
+    setPrivateDescriptorMode(descriptor);
+    return true;
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function setPrivateDescriptorMode(descriptor: number) {
+  if (process.platform !== "win32") fchmodSync(descriptor, 0o600);
+}
+
+function isFileError(error: unknown, code: string) {
+  return error instanceof Error && "code" in error && error.code === code;
 }
 
 function constantTimeEqual(expected: string, candidate: string) {

--- a/apps/server/src/http/routes/accounts.ts
+++ b/apps/server/src/http/routes/accounts.ts
@@ -27,22 +27,14 @@ import { createLogger } from "../../util/logger.js";
 
 const routeLogger = createLogger("routes");
 const qrLoginRateLimit = {
-  config: {
-    rateLimit: {
-      max: 10,
-      timeWindow: "1 minute",
-      groupId: "steam-qr-login",
-    },
-  },
+  max: 10,
+  timeWindow: "1 minute",
+  groupId: "steam-qr-login",
 };
 const credentialLoginRateLimit = {
-  config: {
-    rateLimit: {
-      max: 3,
-      timeWindow: "1 minute",
-      groupId: "steam-credential-login",
-    },
-  },
+  max: 3,
+  timeWindow: "1 minute",
+  groupId: "steam-credential-login",
 };
 
 type SteamProfile = {
@@ -84,7 +76,10 @@ export async function registerAccountRoutes(app: FastifyInstance) {
 
   app.post(
     "/api/steam/login/qr/start",
-    { preHandler: requireAuth, ...qrLoginRateLimit },
+    {
+      preHandler: requireAuth,
+      config: { rateLimit: qrLoginRateLimit },
+    },
     async (request) => {
       return startQrLogin(operationContext(request, "steam-login-qr"));
     },
@@ -109,7 +104,10 @@ export async function registerAccountRoutes(app: FastifyInstance) {
 
   app.post(
     "/api/steam/login/credentials",
-    { preHandler: requireAuth, ...credentialLoginRateLimit },
+    {
+      preHandler: requireAuth,
+      config: { rateLimit: credentialLoginRateLimit },
+    },
     async (request) => {
       const body = credentialsLoginSchema.parse(request.body);
       const { CredentialLoginFlow } = await import("../../steam/login.js");
@@ -463,7 +461,7 @@ async function getSteamProfile(
   }
 }
 
-function readXmlTag(xml: string, tag: string) {
+export function readXmlTag(xml: string, tag: string) {
   const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = xml.match(
     new RegExp(
@@ -471,13 +469,22 @@ function readXmlTag(xml: string, tag: string) {
       "i",
     ),
   );
-  const rawValue = match?.[1] ?? match?.[2];
-  if (!rawValue) return null;
-  return rawValue
-    .replaceAll("&amp;", "&")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">")
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#39;", "'")
+  const cdataValue = match?.[1];
+  if (cdataValue !== undefined) return cdataValue.trim() || null;
+
+  const escapedValue = match?.[2];
+  if (!escapedValue) return null;
+  return escapedValue
+    .replace(/&(amp|lt|gt|quot|#39);/g, (entity) => {
+      return xmlEntityValues[entity] ?? entity;
+    })
     .trim();
 }
+
+const xmlEntityValues: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+};

--- a/apps/server/src/http/routes/system.ts
+++ b/apps/server/src/http/routes/system.ts
@@ -10,6 +10,12 @@ import { steamManager } from "../../steam/manager.js";
 import { getSseClientCount, registerSseClient } from "../events.js";
 import { requireAuth } from "../plugins.js";
 
+const systemReadRateLimit = {
+  max: 60,
+  timeWindow: "1 minute",
+  groupId: "system-read",
+};
+
 export async function registerSystemRoutes(app: FastifyInstance) {
   app.get("/healthz", async () => ({ ok: true }));
 
@@ -25,50 +31,71 @@ export async function registerSystemRoutes(app: FastifyInstance) {
     return { ok: true, code: "READY" };
   });
 
-  app.get("/api/diagnostics", { preHandler: requireAuth }, async () => {
-    const recentEvents = await db
-      .select({
-        level: steamEvent.level,
-        type: steamEvent.type,
-        createdAt: steamEvent.createdAt,
-      })
-      .from(steamEvent)
-      .orderBy(desc(steamEvent.createdAt))
-      .limit(500);
-    const accounts = await db.select().from(steamAccount);
+  app.get(
+    "/api/diagnostics",
+    {
+      preHandler: requireAuth,
+      config: { rateLimit: systemReadRateLimit },
+    },
+    async () => {
+      const recentEvents = await db
+        .select({
+          level: steamEvent.level,
+          type: steamEvent.type,
+          createdAt: steamEvent.createdAt,
+        })
+        .from(steamEvent)
+        .orderBy(desc(steamEvent.createdAt))
+        .limit(500);
+      const accounts = await db.select().from(steamAccount);
 
-    return {
-      build: config.build,
-      logging: {
-        level: config.logLevel,
-        requests: config.logRequests,
-        quietRequests: config.logQuietRequests,
-      },
-      runtime: {
-        dataDir: config.dataDir,
-        publicDir: config.publicDir,
-        sseClients: getSseClientCount(),
-      },
-      migrations: getMigrationState(),
-      events: summarizeEvents(recentEvents),
-      accounts: {
-        total: accounts.length,
-        desiredRunning: accounts.filter(
-          (account) => account.desiredState === "running",
-        ).length,
-      },
-    };
-  });
+      return {
+        build: config.build,
+        logging: {
+          level: config.logLevel,
+          requests: config.logRequests,
+          quietRequests: config.logQuietRequests,
+        },
+        runtime: {
+          dataDir: config.dataDir,
+          publicDir: config.publicDir,
+          sseClients: getSseClientCount(),
+        },
+        migrations: getMigrationState(),
+        events: summarizeEvents(recentEvents),
+        accounts: {
+          total: accounts.length,
+          desiredRunning: accounts.filter(
+            (account) => account.desiredState === "running",
+          ).length,
+        },
+      };
+    },
+  );
 
-  app.get("/api/events/recent", { preHandler: requireAuth }, async () => {
-    return db
-      .select()
-      .from(steamEvent)
-      .orderBy(desc(steamEvent.createdAt))
-      .limit(100);
-  });
+  app.get(
+    "/api/events/recent",
+    {
+      preHandler: requireAuth,
+      config: { rateLimit: systemReadRateLimit },
+    },
+    async () => {
+      return db
+        .select()
+        .from(steamEvent)
+        .orderBy(desc(steamEvent.createdAt))
+        .limit(100);
+    },
+  );
 
-  app.get("/api/system/status", { preHandler: requireAuth }, getSystemStatus);
+  app.get(
+    "/api/system/status",
+    {
+      preHandler: requireAuth,
+      config: { rateLimit: systemReadRateLimit },
+    },
+    getSystemStatus,
+  );
 
   app.get(
     "/api/events",

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -11,6 +11,7 @@ import {
   steamAppCache,
 } from "../src/db/schema.js";
 import { buildApp } from "../src/app.js";
+import { readXmlTag } from "../src/http/routes/accounts.js";
 
 describe("api auth flow", () => {
   beforeEach(() => {
@@ -39,6 +40,18 @@ describe("api auth flow", () => {
     ]);
     expect(() => parseTrustProxy("10.0.0.0/99")).toThrow(/TRUST_PROXY/);
     expect(() => parseTrustProxy("anywhere")).toThrow(/TRUST_PROXY/);
+  });
+
+  it("decodes XML text once and preserves CDATA content", () => {
+    expect(readXmlTag("<steamID>&lt;Admin&gt;</steamID>", "steamID")).toBe(
+      "<Admin>",
+    );
+    expect(
+      readXmlTag("<steamID>&amp;lt;Admin&amp;gt;</steamID>", "steamID"),
+    ).toBe("&lt;Admin&gt;");
+    expect(
+      readXmlTag("<steamID><![CDATA[A &amp; B]]></steamID>", "steamID"),
+    ).toBe("A &amp; B");
   });
 
   it("does not let forwarded IP rotation bypass the admin auth limit", async () => {


### PR DESCRIPTION
## Summary

- make setup-token creation race-free with exclusive file descriptors
- add explicit route-level rate limits for authenticated system reads and Steam login starts
- decode Steam profile XML entities exactly once and preserve CDATA content

## Checklist

- [x] I ran `pnpm format:check`, `pnpm check`, and `pnpm test`.
- [x] I validated relevant Compose changes with `docker compose config`.
- [x] I did not add `.env`, `/data`, SQLite files, Steam client data, or local screenshots.
- [x] Any public screenshots use synthetic accounts and fake SteamIDs only.
- [x] Documentation and Docker examples are updated for user-facing changes.
- [x] I have read and agree to [CLA.md](https://github.com/ill-yes/steam-bee/blob/main/CLA.md) for copyrightable contributions.