### PR TITLE
release: prepare SteamBee 1.0.4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # require the one-time token printed in the container logs and /data/setup.token.
 STEAM_BEE_BIND=127.0.0.1
 STEAM_BEE_PORT=3000
-# STEAM_BEE_IMAGE=ghcr.io/ill-yes/steam-bee:1.0.3
+# STEAM_BEE_IMAGE=ghcr.io/ill-yes/steam-bee:1.0.4
 
 # For one HTTPS reverse proxy, set TRUST_PROXY=1 and COOKIE_SECURE=true.
 # Keep the application port inaccessible from untrusted networks. For multiple
@@ -21,7 +21,7 @@ LOG_QUIET_REQUESTS=true
 # Optional fixed setup token for automated provisioning. When omitted, SteamBee
 # generates /data/setup.token with mode 0600 and prints it only when first
 # created. Read the file after later restarts. Never commit a real token.
-# SETUP_TOKEN=replace-with-at-least-16-random-characters
+# SETUP_TOKEN=at-least-8-random-characters
 
 # Set to 0 to disable automatic event cleanup.
 EVENT_RETENTION_DAYS=90

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN rm -rf \
   /usr/local/bin/corepack \
   /usr/local/bin/yarn \
   /usr/local/bin/yarnpkg
-ARG VERSION=1.0.3-dev
+ARG VERSION=1.0.4-dev
 ARG REVISION=unknown
 ARG BUILD_DATE=unknown
 ARG SOURCE_URL=https://github.com/ill-yes/steam-bee

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ read the file after a later restart with:
 docker compose -f compose.image.yml exec steam-bee cat /data/setup.token
 ```
 
-Set `SETUP_TOKEN` only for automated provisioning; environment-provided tokens
-are deliberately not printed.
+Set `SETUP_TOKEN` only for automated provisioning. Configured tokens must have
+8 to 256 characters and are deliberately not printed.
 
 ## Optional Configuration
 
@@ -156,11 +156,11 @@ For a LAN-accessible Unraid or VPS setup without a local reverse proxy, only set
 
 ## Image Versions
 
-`compose.image.yml` defaults to `ghcr.io/ill-yes/steam-bee:1.0.3`. Override the
+`compose.image.yml` defaults to `ghcr.io/ill-yes/steam-bee:1.0.4`. Override the
 pin in `.env` when you want to select another release:
 
 ```bash
-STEAM_BEE_IMAGE=ghcr.io/ill-yes/steam-bee:1.0.3
+STEAM_BEE_IMAGE=ghcr.io/ill-yes/steam-bee:1.0.4
 ```
 
 Exact version tags are recommended for repeatable deployments. Image tags do
@@ -170,7 +170,7 @@ not include the Git tag's `v` prefix: `1.0` tracks the latest `1.0.x` patch,
 The included GitHub Actions workflow verifies formatting, types, tests,
 dependency and image vulnerabilities, Compose parity, runtime UID/GID, an
 amd64 image smoke test, and multi-architecture builds. `main` publishes only
-`edge` and `sha-*`; a Git tag such as `v1.0.3` publishes `1.0.3`, `1.0`, and
+`edge` and `sha-*`; a Git tag such as `v1.0.4` publishes `1.0.4`, `1.0`, and
 `latest` for `linux/amd64` and `linux/arm64`. Published images include SBOM,
 provenance, and a GitHub artifact attestation. Manual workflow runs build but
 does not publish. The GHCR package is public and can be pulled without
@@ -179,7 +179,7 @@ authentication.
 Verify a published image against this repository with the GitHub CLI:
 
 ```bash
-gh attestation verify oci://ghcr.io/ill-yes/steam-bee:1.0.3 \
+gh attestation verify oci://ghcr.io/ill-yes/steam-bee:1.0.4 \
   --repo ill-yes/steam-bee
 ```
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steam-bee/server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/apps/server/src/auth/setup-token.ts
+++ b/apps/server/src/auth/setup-token.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { ERROR_CODES } from "@steam-bee/contracts";
-import { config, paths } from "../config.js";
+import { config, MIN_SETUP_TOKEN_LENGTH, paths } from "../config.js";
 import { appError } from "../http/errors.js";
 import { createLogger } from "../util/logger.js";
 
@@ -80,7 +80,7 @@ function readSetupTokenFile() {
   try {
     setPrivateDescriptorMode(descriptor);
     const token = readFileSync(descriptor, "utf8").trim();
-    if (token.length < 16) {
+    if (token.length < MIN_SETUP_TOKEN_LENGTH) {
       throw new Error(
         `Setup token at ${paths.setupToken} is invalid. Remove it to generate a new token.`,
       );

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 
 const privateDirectoryMode = 0o700;
 const privateFileMode = 0o600;
+export const MIN_SETUP_TOKEN_LENGTH = 8;
 const trueProxyAliases = new Set(["true", "yes", "on"]);
 const falseProxyAliases = new Set(["false", "no", "off", "0"]);
 
@@ -55,6 +56,11 @@ const trustProxySchema = z
     }
   });
 
+const configuredSetupTokenSchema = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  z.string().min(MIN_SETUP_TOKEN_LENGTH).max(256).optional(),
+);
+
 const envSchema = z.object({
   HOST: z.string().default("0.0.0.0"),
   PORT: z.coerce.number().int().positive().default(3000),
@@ -77,10 +83,7 @@ const envSchema = z.object({
     .string()
     .optional()
     .transform((value) => (value === undefined ? true : value === "true")),
-  SETUP_TOKEN: z.preprocess(
-    (value) => (value === "" ? undefined : value),
-    z.string().min(16).max(256).optional(),
-  ),
+  SETUP_TOKEN: configuredSetupTokenSchema,
   EVENT_RETENTION_DAYS: z.coerce.number().int().min(0).default(90),
   BUILD_VERSION: z.string().default("0.1.0-dev"),
   BUILD_REVISION: z.string().default("unknown"),

--- a/apps/server/tests/config.test.ts
+++ b/apps/server/tests/config.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("runtime configuration", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("accepts a configured setup token with eight characters", async () => {
+    vi.stubEnv("SETUP_TOKEN", "12345678");
+
+    const { config } = await import("../src/config.js");
+
+    expect(config.setupToken).toBe("12345678");
+  });
+
+  it("rejects a configured setup token with seven characters", async () => {
+    vi.stubEnv("SETUP_TOKEN", "1234567");
+
+    await expect(import("../src/config.js")).rejects.toThrow(
+      /at least 8 character/,
+    );
+  });
+
+  it("keeps an empty setup token optional", async () => {
+    vi.stubEnv("SETUP_TOKEN", "");
+
+    const { config } = await import("../src/config.js");
+
+    expect(config.setupToken).toBeUndefined();
+  });
+});

--- a/apps/server/tests/setup-token.test.ts
+++ b/apps/server/tests/setup-token.test.ts
@@ -1,0 +1,36 @@
+import { writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assertSetupToken,
+  completeSetupToken,
+  initializeSetupToken,
+} from "../src/auth/setup-token.js";
+import { config, paths } from "../src/config.js";
+
+describe("persisted setup token", () => {
+  const originalSetupToken = config.setupToken;
+
+  beforeEach(() => {
+    completeSetupToken();
+    config.setupToken = undefined;
+  });
+
+  afterEach(() => {
+    completeSetupToken();
+    config.setupToken = originalSetupToken;
+  });
+
+  it("accepts a stored setup token with eight characters", () => {
+    writeFileSync(paths.setupToken, "12345678\n", "utf8");
+
+    initializeSetupToken(false);
+
+    expect(() => assertSetupToken("12345678")).not.toThrow();
+  });
+
+  it("rejects a stored setup token with seven characters", () => {
+    writeFileSync(paths.setupToken, "1234567\n", "utf8");
+
+    expect(() => initializeSetupToken(false)).toThrow(/is invalid/);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steam-bee/web",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/compose.image.yml
+++ b/compose.image.yml
@@ -1,6 +1,6 @@
 services:
   steam-bee:
-    image: "${STEAM_BEE_IMAGE:-ghcr.io/ill-yes/steam-bee:1.0.3}"
+    image: "${STEAM_BEE_IMAGE:-ghcr.io/ill-yes/steam-bee:1.0.4}"
     restart: unless-stopped
     init: true
     user: "10001:10001"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-bee",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "description": "Self-hosted Steam hour booster with a secure management UI.",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steam-bee/contracts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/templates/steam-bee.xml
+++ b/templates/steam-bee.xml
@@ -32,6 +32,6 @@
   <Config Name="Log Level" Target="LOG_LEVEL" Default="info" Description="Logging level: fatal, error, warn, info, debug, trace, or silent." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Request Logging" Target="LOG_REQUESTS" Default="true" Description="Log incoming HTTP requests." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Quiet Request Logging" Target="LOG_QUIET_REQUESTS" Default="true" Description="Suppress routine health and status requests in the logs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Setup Token" Target="SETUP_TOKEN" Default="" Description="Optional fixed setup token of 16 to 256 characters. Leave empty to generate one automatically." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Setup Token" Target="SETUP_TOKEN" Default="" Description="Optional fixed setup token of 8 to 256 characters. Leave empty to generate one automatically." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Event Retention Days" Target="EVENT_RETENTION_DAYS" Default="90" Description="Days to retain events. Set to 0 to disable automatic cleanup." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
## Summary

- lower the configured setup-token minimum from 16 to 8 characters
- keep generated setup tokens unchanged and centralize persisted-token validation
- add 7/8-character boundary tests
- update the Unraid template, documentation, and release pins for 1.0.4

## Checklist

- [x] I ran `pnpm format:check`, `pnpm check`, and `pnpm test`.
- [x] I validated relevant Compose changes with `docker compose config`.
- [x] I did not add `.env`, `/data`, SQLite files, Steam client data, or local screenshots.
- [x] Any public screenshots use synthetic accounts and fake SteamIDs only.
- [x] Documentation and Docker examples are updated for user-facing changes.
- [x] I have read and agree to [CLA.md](https://github.com/ill-yes/steam-bee/blob/main/CLA.md) for copyrightable contributions.

Additional verification: dependency audit, Compose parity, XML validation, Docker build, and container smoke test with `SETUP_TOKEN=12345678`.