### PR TITLE
release: SteamBee 1.0.5 with automatic Unraid permissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # require the one-time token printed in the container logs and /data/setup.token.
 STEAM_BEE_BIND=127.0.0.1
 STEAM_BEE_PORT=3000
-# STEAM_BEE_IMAGE=ghcr.io/ill-yes/steam-bee:1.0.4
+# STEAM_BEE_IMAGE=ghcr.io/ill-yes/steam-bee:1.0.5
 
 # For one HTTPS reverse proxy, set TRUST_PROXY=1 and COOKIE_SECURE=true.
 # Keep the application port inaccessible from untrusted networks. For multiple

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,6 +22,7 @@ jobs:
   quality:
     name: Quality gate
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -60,6 +61,9 @@ jobs:
       - name: Check Compose runtime parity
         run: pnpm compose:check
 
+      - name: Validate Unraid template runtime
+        run: pnpm unraid:check
+
       - name: Dependency review
         if: github.event_name == 'pull_request'
         continue-on-error: ${{ github.event.repository.private }}
@@ -72,6 +76,7 @@ jobs:
     needs: quality
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -109,22 +114,14 @@ jobs:
           ignore-unfixed: true
 
       - name: Smoke-test image
-        run: |
-          docker volume create steam-bee-ci-data
-          trap 'docker rm -f steam-bee-ci >/dev/null 2>&1 || true; docker volume rm steam-bee-ci-data >/dev/null 2>&1 || true' EXIT
-          docker run -d --name steam-bee-ci --read-only --tmpfs /tmp:rw,noexec,nosuid,size=64m -v steam-bee-ci-data:/data -e SETUP_TOKEN=steam-bee-ci-setup-token steam-bee:ci
-          for _attempt in $(seq 1 30); do
-            docker exec steam-bee-ci node -e "if(process.getuid()!==10001||process.getgid()!==10001)throw new Error('unexpected runtime identity');Promise.all([fetch('http://127.0.0.1:3000/readyz').then(r=>{if(!r.ok)throw new Error('not ready')}),fetch('http://127.0.0.1:3000/').then(async r=>{if(!r.ok||!(await r.text()).includes('SteamBee'))throw new Error('ui unavailable')})]).then(()=>process.exit(0)).catch(()=>process.exit(1))" && exit 0
-            sleep 1
-          done
-          docker logs steam-bee-ci
-          exit 1
+        run: sh scripts/smoke-test-image.sh steam-bee:ci steam-bee-ci
 
   publish:
     name: Publish image
     needs: quality
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -193,16 +190,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Smoke-test amd64 image
-        run: |
-          docker volume create steam-bee-smoke-data
-          trap 'docker rm -f steam-bee-smoke >/dev/null 2>&1 || true; docker volume rm steam-bee-smoke-data >/dev/null 2>&1 || true' EXIT
-          docker run -d --name steam-bee-smoke --read-only --tmpfs /tmp:rw,noexec,nosuid,size=64m -v steam-bee-smoke-data:/data -e SETUP_TOKEN=steam-bee-ci-setup-token steam-bee:smoke
-          for _attempt in $(seq 1 30); do
-            docker exec steam-bee-smoke node -e "if(process.getuid()!==10001||process.getgid()!==10001)throw new Error('unexpected runtime identity');Promise.all([fetch('http://127.0.0.1:3000/readyz').then(r=>{if(!r.ok)throw new Error('not ready')}),fetch('http://127.0.0.1:3000/').then(async r=>{if(!r.ok||!(await r.text()).includes('SteamBee'))throw new Error('ui unavailable')})]).then(()=>process.exit(0)).catch(()=>process.exit(1))" && exit 0
-            sleep 1
-          done
-          docker logs steam-bee-smoke
-          exit 1
+        run: sh scripts/smoke-test-image.sh steam-bee:smoke steam-bee-smoke
 
       - name: Build and push multi-arch image
         id: push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,14 @@ pnpm audit --audit-level=high
 docker compose config
 docker compose -f compose.image.yml config
 pnpm compose:check
+pnpm unraid:check
 ```
 
 For Docker changes, also run:
 
 ```bash
 docker build --pull=false -t steam-bee:local .
+sh scripts/smoke-test-image.sh steam-bee:local steam-bee-local
 ```
 
 ## Contribution Licensing

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN rm -rf \
   /usr/local/bin/corepack \
   /usr/local/bin/yarn \
   /usr/local/bin/yarnpkg
-ARG VERSION=1.0.4-dev
+ARG VERSION=1.0.5-dev
 ARG REVISION=unknown
 ARG BUILD_DATE=unknown
 ARG SOURCE_URL=https://github.com/ill-yes/steam-bee
@@ -64,8 +64,10 @@ RUN groupadd --gid 10001 steambee \
   && mkdir -p /data \
   && chown -R steambee:steambee /data /app
 COPY --from=build --chown=steambee:steambee /prod ./
+COPY --chmod=0755 docker/steam-bee-entrypoint.sh /usr/local/bin/steam-bee-entrypoint
 USER 10001:10001
 EXPOSE 3000
 VOLUME ["/data"]
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/readyz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+ENTRYPOINT ["/usr/local/bin/steam-bee-entrypoint"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD ["/usr/local/bin/steam-bee-entrypoint", "--healthcheck", "node", "-e", "if(process.getuid?.()===0||process.getgid?.()===0)process.exit(1);fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/readyz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ For a LAN-accessible Unraid or VPS setup without a local reverse proxy, only set
 
 ## Image Versions
 
-`compose.image.yml` defaults to `ghcr.io/ill-yes/steam-bee:1.0.4`. Override the
+`compose.image.yml` defaults to `ghcr.io/ill-yes/steam-bee:1.0.5`. Override the
 pin in `.env` when you want to select another release:
 
 ```bash
-STEAM_BEE_IMAGE=ghcr.io/ill-yes/steam-bee:1.0.4
+STEAM_BEE_IMAGE=ghcr.io/ill-yes/steam-bee:1.0.5
 ```
 
 Exact version tags are recommended for repeatable deployments. Image tags do
@@ -169,8 +169,9 @@ not include the Git tag's `v` prefix: `1.0` tracks the latest `1.0.x` patch,
 
 The included GitHub Actions workflow verifies formatting, types, tests,
 dependency and image vulnerabilities, Compose parity, runtime UID/GID, an
-amd64 image smoke test, and multi-architecture builds. `main` publishes only
-`edge` and `sha-*`; a Git tag such as `v1.0.4` publishes `1.0.4`, `1.0`, and
+Unraid template check, both standard and PUID/PGID image smoke tests, and
+multi-architecture builds. `main` publishes only
+`edge` and `sha-*`; a Git tag such as `v1.0.5` publishes `1.0.5`, `1.0`, and
 `latest` for `linux/amd64` and `linux/arm64`. Published images include SBOM,
 provenance, and a GitHub artifact attestation. Manual workflow runs build but
 does not publish. The GHCR package is public and can be pulled without
@@ -179,7 +180,7 @@ authentication.
 Verify a published image against this repository with the GitHub CLI:
 
 ```bash
-gh attestation verify oci://ghcr.io/ill-yes/steam-bee:1.0.4 \
+gh attestation verify oci://ghcr.io/ill-yes/steam-bee:1.0.5 \
   --repo ill-yes/steam-bee
 ```
 
@@ -244,7 +245,25 @@ volumes:
   - /mnt/user/appdata/steambee:/data
 ```
 
-The container runs as UID/GID `10001`. Make sure the bind-mounted directory is writable by that user, and never point `/data` at the checked-out repository.
+The standard image and both Compose files run as UID/GID `10001` exactly as
+before. Make sure custom bind mounts are writable by that user, and never point
+`/data` at the checked-out repository.
+
+The official Unraid template uses Unraid's conventional `PUID=99` and
+`PGID=100`. Its restricted startup helper changes ownership only inside
+`/data`, clears every inherited, permitted, effective, bounding, and ambient
+capability, and then replaces itself with the Node process as that unprivileged
+user. New Unraid installations therefore require no host-side `chown` command.
+Changing PUID or PGID in the template automatically migrates existing appdata
+ownership on the next start.
+
+Keep the template's Appdata mapping pointed at one dedicated SteamBee
+directory (the default is `/mnt/user/appdata/steambee`). Before changing any
+ownership, the helper requires an empty, previously marked, or recognizable
+SteamBee data directory and rejects unexpected top-level entries, hardlinks,
+symlinks, special files, and nested mounts. This prevents an accidentally
+broad mapping such as `/mnt/user/appdata` from rewriting other containers'
+data.
 
 The commands below use `compose.image.yml`. If you built from source, omit
 `-f compose.image.yml`. The local `backups/` directory is ignored by Git and
@@ -296,6 +315,13 @@ docker compose -f compose.image.yml pull
 docker compose -f compose.image.yml up -d
 docker compose -f compose.image.yml logs -f steam-bee
 ```
+
+Unraid stores an installed container's template locally and does not overwrite
+it with later template revisions. Containers installed before `1.0.5` must be
+recreated once from the current Community Apps template, keeping the same
+Appdata path. The appdata itself remains persistent, and the new template
+adopts it automatically without terminal commands. New installations already
+receive the automatic PUID/PGID initialization.
 
 ## Git Hygiene
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,3 +48,11 @@ proxy and set `TRUST_PROXY=1` and `COOKIE_SECURE=true` when served over HTTPS
 through one trusted proxy. Keep the application port inaccessible from
 untrusted networks and use an exact hop count or trusted CIDR list for more
 complex proxy chains.
+
+The standard image runs as UID/GID `10001`; the supported Compose files also
+drop all capabilities. The Unraid template starts a restricted ownership
+helper for `/data`, then drops to its configured PUID/PGID with an empty
+capability set before Node starts. Its healthcheck applies the same privilege
+drop. Ownership initialization is fail-closed: `/data` must be a dedicated,
+empty or recognizable SteamBee mount without nested mounts, hardlinks,
+symlinks, special files, or unrelated top-level entries.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steam-bee/server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steam-bee/web",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/compose.image.yml
+++ b/compose.image.yml
@@ -1,6 +1,6 @@
 services:
   steam-bee:
-    image: "${STEAM_BEE_IMAGE:-ghcr.io/ill-yes/steam-bee:1.0.4}"
+    image: "${STEAM_BEE_IMAGE:-ghcr.io/ill-yes/steam-bee:1.0.5}"
     restart: unless-stopped
     init: true
     user: "10001:10001"

--- a/docker/steam-bee-entrypoint.sh
+++ b/docker/steam-bee-entrypoint.sh
@@ -1,0 +1,229 @@
+#!/bin/sh
+set -eu
+
+upstream_entrypoint=/usr/local/bin/docker-entrypoint.sh
+max_runtime_id=2147483647
+data_marker=/data/.steam-bee-data-v1
+current_uid=$(/usr/bin/id -u)
+
+if [ "$current_uid" -eq 0 ]; then
+  # Never resolve privileged initialization tools through a user-controlled PATH.
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  export PATH
+fi
+
+fail() {
+  printf 'SteamBee entrypoint: %s\n' "$*" >&2
+  exit 64
+}
+
+validate_runtime_id() {
+  id_name=$1
+  id_value=$2
+
+  case "$id_value" in
+    "" | 0 | 0* | *[!0-9]*)
+      fail "$id_name must be a decimal integer between 1 and $max_runtime_id."
+      ;;
+  esac
+
+  if ! [ "$id_value" -le "$max_runtime_id" ] 2>/dev/null; then
+    fail "$id_name must be a decimal integer between 1 and $max_runtime_id."
+  fi
+}
+
+load_runtime_ids() {
+  runtime_uid=${PUID:-}
+  runtime_gid=${PGID:-}
+  validate_runtime_id PUID "$runtime_uid"
+  validate_runtime_id PGID "$runtime_gid"
+}
+
+validate_data_mount() {
+  [ -r /proc/self/mountinfo ] ||
+    fail "cannot verify the /data mount boundary."
+
+  awk '
+    $5 == "/data" { data_mounts++ }
+    index($5, "/data/") == 1 { nested_mount = 1 }
+    END { exit !(data_mounts == 1 && nested_mount != 1) }
+  ' /proc/self/mountinfo ||
+    fail "/data must be one dedicated mount without nested mounts."
+}
+
+validate_known_path() {
+  path=$1
+  expected_type=$2
+
+  case "$expected_type" in
+    file)
+      [ -f "$path" ] && [ ! -L "$path" ] ||
+        fail "the /data layout contains an invalid SteamBee file type."
+      ;;
+    directory)
+      [ -d "$path" ] && [ ! -L "$path" ] ||
+        fail "the /data layout contains an invalid SteamBee directory type."
+      ;;
+  esac
+}
+
+validate_data_layout() {
+  has_entries=false
+  has_marker=false
+
+  for path in /data/* /data/.[!.]* /data/..?*; do
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+      continue
+    fi
+
+    has_entries=true
+    case "${path##*/}" in
+      instance.secret | setup.token | steam-bee.sqlite | \
+        steam-bee.sqlite-wal | steam-bee.sqlite-shm | \
+        steam-bee.sqlite-journal)
+        validate_known_path "$path" file
+        ;;
+      steam-data)
+        validate_known_path "$path" directory
+        ;;
+      .steam-bee-data-v1)
+        validate_known_path "$path" directory
+        marker_entry=$(find "$path" -mindepth 1 -maxdepth 1 -print -quit) ||
+          fail "could not inspect the SteamBee data marker."
+        [ -z "$marker_entry" ] || fail "the SteamBee data marker is invalid."
+        has_marker=true
+        ;;
+      *)
+        fail "refusing ownership changes: /data is not an empty or recognized SteamBee data directory."
+        ;;
+    esac
+  done
+
+  if [ "$has_entries" = "false" ] || [ "$has_marker" = "true" ]; then
+    return
+  fi
+
+  [ -d /data/steam-data ] &&
+    [ -f /data/instance.secret ] &&
+    [ -f /data/steam-bee.sqlite ] ||
+    fail "refusing ownership changes: unmarked /data is not recognizable SteamBee data."
+}
+
+validate_data_tree() {
+  unsafe_path=$(
+    find /data -xdev -mindepth 1 ! -type d ! -type f -print -quit
+  ) || fail "could not inspect the SteamBee data tree."
+  [ -z "$unsafe_path" ] ||
+    fail "refusing ownership changes: /data contains a symlink or special file."
+
+  hardlinked_path=$(
+    find /data -xdev -type f -links +1 -print -quit
+  ) || fail "could not inspect SteamBee file links."
+  [ -z "$hardlinked_path" ] ||
+    fail "refusing ownership changes: /data contains a hardlinked file."
+}
+
+migrate_data_ownership() {
+  chown --no-dereference "$runtime_uid:$runtime_gid" -- /data
+
+  for path in \
+    /data/instance.secret \
+    /data/setup.token \
+    /data/steam-bee.sqlite \
+    /data/steam-bee.sqlite-wal \
+    /data/steam-bee.sqlite-shm \
+    /data/steam-bee.sqlite-journal \
+    "$data_marker"
+  do
+    [ -e "$path" ] || continue
+    chown --no-dereference "$runtime_uid:$runtime_gid" -- "$path"
+  done
+
+  if [ -d /data/steam-data ]; then
+    find /data/steam-data -xdev \
+      \( -type d -o -type f \) \
+      \( ! -uid "$runtime_uid" -o ! -gid "$runtime_gid" \) \
+      -exec chown --no-dereference "$runtime_uid:$runtime_gid" -- {} +
+  fi
+}
+
+create_data_marker() {
+  [ -d "$data_marker" ] && return
+
+  # $1 is expanded by the unprivileged child shell, not this entrypoint.
+  # shellcheck disable=SC2016
+  setpriv \
+    --reuid "$runtime_uid" \
+    --regid "$runtime_gid" \
+    --clear-groups \
+    --bounding-set=-all \
+    --inh-caps=-all \
+    --ambient-caps=-all \
+    --no-new-privs \
+    -- sh -eu -c 'umask 077; mkdir -- "$1"' sh "$data_marker" ||
+    fail "could not create the SteamBee data marker."
+}
+
+exec_as_runtime_user() {
+  export HOME=/data
+  export USER=steambee
+  export LOGNAME=steambee
+
+  exec setpriv \
+    --reuid "$runtime_uid" \
+    --regid "$runtime_gid" \
+    --clear-groups \
+    --bounding-set=-all \
+    --inh-caps=-all \
+    --ambient-caps=-all \
+    --no-new-privs \
+    -- "$@"
+}
+
+if [ "${1:-}" = "--healthcheck" ]; then
+  shift
+  [ "$#" -gt 0 ] || fail "the healthcheck command is missing."
+
+  if [ "$current_uid" -eq 0 ]; then
+    load_runtime_ids
+    exec_as_runtime_user "$@"
+  fi
+
+  exec "$@"
+fi
+
+if [ "$current_uid" -eq 0 ]; then
+  if [ "${STEAM_BEE_DATA_INIT:-false}" != "true" ]; then
+    if [ "${1:-}" = "node" ] && [ "${2:-}" = "dist/index.js" ]; then
+      fail "refusing to start the application as root without STEAM_BEE_DATA_INIT=true."
+    fi
+
+    exec "$upstream_entrypoint" "$@"
+  fi
+
+  load_runtime_ids
+  [ "${DATA_DIR:-/data}" = "/data" ] ||
+    fail "automatic ownership initialization supports only DATA_DIR=/data."
+  [ -d /data ] && [ ! -L /data ] || fail "/data must be a directory."
+
+  validate_data_mount
+  validate_data_layout
+  validate_data_tree
+
+  printf 'SteamBee: preparing /data for PUID=%s PGID=%s\n' \
+    "$runtime_uid" "$runtime_gid"
+
+  migrate_data_ownership
+  create_data_marker
+
+  exec_as_runtime_user "$upstream_entrypoint" "$@"
+fi
+
+if [ "${STEAM_BEE_DATA_INIT:-false}" = "true" ]; then
+  load_runtime_ids
+  [ "$current_uid" -eq "$runtime_uid" ] &&
+    [ "$(/usr/bin/id -g)" -eq "$runtime_gid" ] ||
+    fail "STEAM_BEE_DATA_INIT=true requires root startup or matching PUID/PGID."
+fi
+
+exec "$upstream_entrypoint" "$@"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-bee",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "description": "Self-hosted Steam hour booster with a secure management UI.",
@@ -23,6 +23,7 @@
     "build": "pnpm -r build",
     "check": "pnpm contracts:build && pnpm -r check",
     "compose:check": "node scripts/check-compose-parity.mjs",
+    "unraid:check": "node scripts/check-unraid-template.mjs",
     "contracts:build": "pnpm --filter @steam-bee/contracts build",
     "dev": "pnpm --filter @steam-bee/server dev",
     "format": "prettier --write .",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steam-bee/contracts",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/scripts/check-unraid-template.mjs
+++ b/scripts/check-unraid-template.mjs
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+
+const template = readFileSync("templates/steam-bee.xml", "utf8");
+const extraParams = readTag("ExtraParams").split(/\s+/).filter(Boolean);
+const expectedParams = [
+  "--entrypoint=/usr/local/bin/steam-bee-entrypoint",
+  "--user=0:0",
+  "--pids-limit=256",
+  "--cap-drop=ALL",
+  "--cap-add=CHOWN",
+  "--cap-add=DAC_READ_SEARCH",
+  "--cap-add=SETGID",
+  "--cap-add=SETPCAP",
+  "--cap-add=SETUID",
+  "--security-opt=no-new-privileges=true",
+  "--read-only",
+  "--tmpfs=/tmp:rw,noexec,nosuid,nodev,size=64m",
+  "--stop-timeout=30",
+  "--log-opt=max-size=10m",
+  "--log-opt=max-file=3",
+];
+
+if (
+  extraParams.length !== expectedParams.length ||
+  extraParams.some((param, index) => param !== expectedParams[index])
+) {
+  fail(
+    `ExtraParams must exactly match the reviewed runtime policy.\nExpected: ${expectedParams.join(" ")}\nReceived: ${extraParams.join(" ")}`,
+  );
+}
+
+assertConfig("PUID", { Default: "99", Required: "true" });
+assertConfig("PGID", { Default: "100", Required: "true" });
+assertConfig("STEAM_BEE_DATA_INIT", {
+  Default: "true",
+  Required: "true",
+});
+
+if (readTag("Privileged") !== "false") {
+  fail("The Unraid container must not run in privileged mode.");
+}
+
+if (readTag("Repository") !== "ghcr.io/ill-yes/steam-bee:latest") {
+  fail("The Unraid repository must track the stable latest image.");
+}
+
+if (readTag("PostArgs") !== "node dist/index.js") {
+  fail("The Unraid template must pass the SteamBee server command explicitly.");
+}
+
+process.stdout.write("Unraid template runtime settings are valid.\n");
+
+function readTag(name) {
+  const matches = [
+    ...template.matchAll(new RegExp(`<${name}>([^<]+)</${name}>`, "g")),
+  ];
+  if (matches.length !== 1) {
+    fail(`Expected exactly one <${name}> tag, received ${matches.length}.`);
+  }
+  return matches[0][1].trim();
+}
+
+function assertConfig(target, expected) {
+  const matches = [
+    ...template.matchAll(
+      new RegExp(`<Config\\s+[^>]*Target="${target}"[^>]*/>`, "g"),
+    ),
+  ];
+  if (matches.length !== 1) {
+    fail(
+      `Expected exactly one Config for ${target}, received ${matches.length}.`,
+    );
+  }
+
+  const attributes = Object.fromEntries(
+    [...matches[0][0].matchAll(/([A-Za-z]+)="([^"]*)"/g)].map((item) => [
+      item[1],
+      item[2],
+    ]),
+  );
+
+  for (const [name, value] of Object.entries(expected)) {
+    if (attributes[name] !== value) {
+      fail(`${target} must set ${name}="${value}".`);
+    }
+  }
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}

--- a/scripts/smoke-test-image.sh
+++ b/scripts/smoke-test-image.sh
@@ -1,0 +1,444 @@
+#!/bin/sh
+set -eu
+
+image=${1:?Usage: smoke-test-image.sh IMAGE NAME_PREFIX}
+prefix=${2:?Usage: smoke-test-image.sh IMAGE NAME_PREFIX}
+
+default_container=$prefix-default
+migration_container=$prefix-migration
+fresh_container=$prefix-unraid
+failure_container=$prefix-expected-failure
+default_volume=$prefix-default-data
+fresh_volume=$prefix-unraid-data
+guard_volume=$prefix-guard-data
+outside_volume=$prefix-outside-data
+nest_volume=$prefix-nested-data
+invalid_volume=$prefix-invalid-data
+
+cleanup() {
+  for container in \
+    "$default_container" \
+    "$migration_container" \
+    "$fresh_container" \
+    "$failure_container"
+  do
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  done
+
+  for volume in \
+    "$default_volume" \
+    "$fresh_volume" \
+    "$guard_volume" \
+    "$outside_volume" \
+    "$nest_volume" \
+    "$invalid_volume"
+  do
+    docker volume rm "$volume" >/dev/null 2>&1 || true
+  done
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+cleanup
+
+docker run --rm --user 0:0 "$image" sh -c \
+  'test "$(id -u):$(id -g)" = "0:0"'
+
+assert_container_fails() {
+  container=$1
+  expected_message=$2
+  shift 2
+
+  docker run -d --name "$container" "$@" >/dev/null
+  attempt=1
+  while [ "$attempt" -le 8 ]; do
+    container_running=$(
+      docker inspect "$container" --format '{{.State.Running}}'
+    )
+    [ "$container_running" = "true" ] || break
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  if [ "$container_running" = "true" ]; then
+    docker logs "$container"
+    printf '%s\n' "Expected $container to fail, but it remained running." >&2
+    return 1
+  fi
+
+  failure_output=$(docker logs "$container" 2>&1)
+  failure_status=$(
+    docker inspect "$container" --format '{{.State.ExitCode}}'
+  )
+  if [ "$failure_status" != "64" ]; then
+    printf '%s\n' "$failure_output" >&2
+    printf '%s\n' "Expected exit 64 from $container, received $failure_status." >&2
+    return 1
+  fi
+  case "$failure_output" in
+    *"$expected_message"*) ;;
+    *)
+      printf '%s\n' "$failure_output" >&2
+      printf '%s\n' "Expected failure message: $expected_message" >&2
+      return 1
+      ;;
+  esac
+
+  docker rm "$container" >/dev/null
+}
+
+assert_unraid_init_fails() {
+  expected_message=$1
+  shift
+
+  assert_container_fails \
+    "$failure_container" \
+    "$expected_message" \
+    --entrypoint /usr/local/bin/steam-bee-entrypoint \
+    --user 0:0 \
+    --pids-limit 256 \
+    --cap-drop ALL \
+    --cap-add CHOWN \
+    --cap-add DAC_READ_SEARCH \
+    --cap-add SETGID \
+    --cap-add SETPCAP \
+    --cap-add SETUID \
+    --security-opt no-new-privileges=true \
+    --read-only \
+    --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+    "$@" \
+    -e PUID=99 \
+    -e PGID=100 \
+    -e STEAM_BEE_DATA_INIT=true \
+    -e SETUP_TOKEN=12345678 \
+    "$image" node dist/index.js
+}
+
+assert_container_fails \
+  "$failure_container" \
+  "refusing to start the application as root" \
+  --user 0:0 \
+  -e PATH=/data \
+  "$image"
+
+wait_for_app() {
+  container=$1
+  attempt=1
+  while [ "$attempt" -le 30 ]; do
+    if [ "$(docker inspect "$container" --format '{{.State.Running}}')" != "true" ]; then
+      docker logs "$container"
+      printf '%s\n' "Container $container exited before becoming ready." >&2
+      return 1
+    fi
+    if docker exec "$container" node -e "Promise.all([fetch('http://127.0.0.1:3000/readyz').then(r=>{if(!r.ok)throw new Error('not ready')}),fetch('http://127.0.0.1:3000/').then(async r=>{if(!r.ok||!(await r.text()).includes('SteamBee'))throw new Error('ui unavailable')})]).then(()=>process.exit(0)).catch(()=>process.exit(1))"; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  docker logs "$container"
+  return 1
+}
+
+wait_for_health() {
+  container=$1
+  attempt=1
+  while [ "$attempt" -le 30 ]; do
+    if [ "$(docker inspect "$container" --format '{{.State.Running}}')" != "true" ]; then
+      docker logs "$container"
+      printf '%s\n' "Container $container exited before becoming healthy." >&2
+      return 1
+    fi
+
+    health_status=$(
+      docker inspect "$container" \
+        --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}'
+    )
+    case "$health_status" in
+      healthy) return 0 ;;
+      missing)
+        printf '%s\n' "Container $container has no Docker healthcheck." >&2
+        return 1
+        ;;
+    esac
+
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  docker inspect "$container" --format '{{json .State.Health}}'
+  docker logs "$container"
+  printf '%s\n' "Container $container remained $health_status." >&2
+  return 1
+}
+
+assert_runtime_process() {
+  container=$1
+  expected_uid=$2
+  expected_gid=$3
+  expected_home=$4
+
+  docker exec --user "$expected_uid:$expected_gid" -i \
+    "$container" node - "$expected_uid" "$expected_gid" "$expected_home" <<'NODE'
+const fs = require("node:fs");
+
+const expectedUid = Number(process.argv[2]);
+const expectedGid = Number(process.argv[3]);
+const expectedHome = process.argv[4];
+let runtimePid = null;
+
+for (const entry of fs.readdirSync("/proc")) {
+  if (!/^\d+$/.test(entry)) continue;
+  try {
+    const command = fs.readFileSync(`/proc/${entry}/cmdline`, "utf8");
+    if (command === "node\0dist/index.js\0") {
+      runtimePid = entry;
+      break;
+    }
+  } catch {}
+}
+
+if (!runtimePid) throw new Error("SteamBee Node process was not found.");
+
+const status = fs.readFileSync(`/proc/${runtimePid}/status`, "utf8");
+const readField = (name) => {
+  const match = new RegExp(`^${name}:[ \\t]*(.*)$`, "m").exec(status);
+  if (!match) throw new Error(`${name} is missing from process status.`);
+  return match[1].trim();
+};
+const assertIds = (name, expected) => {
+  const values = readField(name).split(/\s+/).map(Number);
+  if (values.some((value) => value !== expected)) {
+    throw new Error(`${name} expected ${expected}, received ${values.join(",")}.`);
+  }
+};
+
+assertIds("Uid", expectedUid);
+assertIds("Gid", expectedGid);
+const groups = readField("Groups");
+if (
+  groups !== "" &&
+  groups
+    .split(/\s+/)
+    .map(Number)
+    .some((group) => group !== expectedGid)
+) {
+  throw new Error(`Unexpected supplementary groups: ${groups}.`);
+}
+for (const name of ["CapInh", "CapPrm", "CapEff", "CapBnd", "CapAmb"]) {
+  if (!/^0+$/.test(readField(name))) {
+    throw new Error(`${name} was not empty: ${readField(name)}.`);
+  }
+}
+if (readField("NoNewPrivs") !== "1") {
+  throw new Error("NoNewPrivs is not enabled.");
+}
+
+const environment = fs
+  .readFileSync(`/proc/${runtimePid}/environ`, "utf8")
+  .split("\0");
+if (!environment.includes(`HOME=${expectedHome}`)) {
+  throw new Error(`Expected HOME=${expectedHome}.`);
+}
+NODE
+}
+
+assert_healthcheck_drop() {
+  container=$1
+  expected_uid=$2
+  expected_gid=$3
+
+  docker exec "$container" /usr/local/bin/steam-bee-entrypoint --healthcheck node -e "const fs=require('node:fs');if(process.getuid()!==$expected_uid||process.getgid()!==$expected_gid)process.exit(1);const status=fs.readFileSync('/proc/self/status','utf8');const groups=/^Groups:[ \\t]*(.*)$/m.exec(status);if(!groups||groups[1].trim().split(/\\s+/).filter(Boolean).map(Number).some(group=>group!==$expected_gid))process.exit(1);for(const name of ['CapInh','CapPrm','CapEff','CapBnd','CapAmb']){if(!new RegExp('^'+name+':[ \\t]+0+$','m').test(status))process.exit(1)}if(!/^NoNewPrivs:[ \\t]+1$/m.test(status))process.exit(1)"
+}
+
+docker volume create "$default_volume" >/dev/null
+docker run -d \
+  --name "$default_container" \
+  --init \
+  --user 10001:10001 \
+  --pids-limit 256 \
+  --cap-drop ALL \
+  --security-opt no-new-privileges=true \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+  --health-interval 1s \
+  --health-timeout 5s \
+  --health-start-period 0s \
+  --health-retries 3 \
+  -v "$default_volume:/data" \
+  -e SETUP_TOKEN=12345678 \
+  "$image" >/dev/null
+
+wait_for_app "$default_container"
+wait_for_health "$default_container"
+assert_runtime_process "$default_container" 10001 10001 /home/steambee
+docker exec "$default_container" sh -c \
+  'test "$(stat -c "%u:%g:%a" /data)" = "10001:10001:700" && test "$(stat -c "%u:%g:%a" /data/steam-data)" = "10001:10001:700" && test "$(stat -c "%u:%g:%a" /data/instance.secret)" = "10001:10001:600"'
+docker exec "$default_container" sh -c \
+  'printf migration-ok > /data/steam-data/migration-sentinel'
+secret_hash=$(docker exec "$default_container" sha256sum /data/instance.secret | awk '{print $1}')
+docker stop -t 10 "$default_container" >/dev/null
+test "$(docker inspect "$default_container" --format '{{.State.ExitCode}}')" = "0"
+docker rm "$default_container" >/dev/null
+
+docker run -d \
+  --name "$migration_container" \
+  --entrypoint /usr/local/bin/steam-bee-entrypoint \
+  --user 0:0 \
+  --pids-limit 256 \
+  --cap-drop ALL \
+  --cap-add CHOWN \
+  --cap-add DAC_READ_SEARCH \
+  --cap-add SETGID \
+  --cap-add SETPCAP \
+  --cap-add SETUID \
+  --security-opt no-new-privileges=true \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+  --health-interval 1s \
+  --health-timeout 5s \
+  --health-start-period 0s \
+  --health-retries 3 \
+  -v "$default_volume:/data" \
+  -e PUID=99 \
+  -e PGID=100 \
+  -e STEAM_BEE_DATA_INIT=true \
+  -e SETUP_TOKEN=12345678 \
+  "$image" node dist/index.js >/dev/null
+
+wait_for_app "$migration_container"
+wait_for_health "$migration_container"
+assert_runtime_process "$migration_container" 99 100 /data
+assert_healthcheck_drop "$migration_container" 99 100
+test "$(docker exec "$migration_container" sha256sum /data/instance.secret | awk '{print $1}')" = "$secret_hash"
+test "$(docker exec "$migration_container" cat /data/steam-data/migration-sentinel)" = "migration-ok"
+docker exec "$migration_container" sh -c \
+  'test -z "$(find /data -xdev \( ! -uid 99 -o ! -gid 100 \) -print -quit)" && test "$(stat -c "%a" /data)" = "700" && test "$(stat -c "%a" /data/instance.secret)" = "600" && test "$(stat -c "%u:%g:%a" /data/.steam-bee-data-v1)" = "99:100:700"'
+marker_inode=$(
+  docker exec "$migration_container" stat -c '%d:%i' /data/.steam-bee-data-v1
+)
+docker restart "$migration_container" >/dev/null
+wait_for_app "$migration_container"
+wait_for_health "$migration_container"
+assert_runtime_process "$migration_container" 99 100 /data
+test "$(docker exec "$migration_container" stat -c '%d:%i' /data/.steam-bee-data-v1)" = "$marker_inode"
+docker stop -t 10 "$migration_container" >/dev/null
+test "$(docker inspect "$migration_container" --format '{{.State.ExitCode}}')" = "0"
+docker rm "$migration_container" >/dev/null
+
+docker volume create "$fresh_volume" >/dev/null
+docker run --rm \
+  --user 0:0 \
+  --entrypoint sh \
+  -v "$fresh_volume:/data" \
+  "$image" \
+  -c 'test -z "$(find /data -mindepth 1 -print -quit)" && chown 0:0 /data && chmod 0755 /data' >/dev/null
+
+docker run -d \
+  --name "$fresh_container" \
+  --entrypoint /usr/local/bin/steam-bee-entrypoint \
+  --user 0:0 \
+  --pids-limit 256 \
+  --cap-drop ALL \
+  --cap-add CHOWN \
+  --cap-add DAC_READ_SEARCH \
+  --cap-add SETGID \
+  --cap-add SETPCAP \
+  --cap-add SETUID \
+  --security-opt no-new-privileges=true \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+  --health-interval 1s \
+  --health-timeout 5s \
+  --health-start-period 0s \
+  --health-retries 3 \
+  -v "$fresh_volume:/data" \
+  -e PUID=99 \
+  -e PGID=100 \
+  -e STEAM_BEE_DATA_INIT=true \
+  -e SETUP_TOKEN=12345678 \
+  "$image" node dist/index.js >/dev/null
+
+wait_for_app "$fresh_container"
+wait_for_health "$fresh_container"
+assert_runtime_process "$fresh_container" 99 100 /data
+assert_healthcheck_drop "$fresh_container" 99 100
+docker exec "$fresh_container" sh -c \
+  'test "$(stat -c "%u:%g:%a" /data)" = "99:100:700" && test "$(stat -c "%u:%g:%a" /data/.steam-bee-data-v1)" = "99:100:700" && test "$(stat -c "%u:%g:%a" /data/instance.secret)" = "99:100:600"'
+docker stop -t 10 "$fresh_container" >/dev/null
+test "$(docker inspect "$fresh_container" --format '{{.State.ExitCode}}')" = "0"
+docker rm "$fresh_container" >/dev/null
+
+docker volume create "$invalid_volume" >/dev/null
+docker run --rm --user 0:0 --entrypoint sh -v "$invalid_volume:/data" "$image" \
+  -c 'touch /data/untouched && chown -R 0:0 /data' >/dev/null
+assert_container_fails \
+  "$failure_container" \
+  "PUID must be a decimal integer" \
+  --entrypoint /usr/local/bin/steam-bee-entrypoint \
+  --user 0:0 \
+  --cap-drop ALL \
+  --cap-add CHOWN \
+  --cap-add DAC_READ_SEARCH \
+  --cap-add SETGID \
+  --cap-add SETPCAP \
+  --cap-add SETUID \
+  --security-opt no-new-privileges=true \
+  -v "$invalid_volume:/data" \
+  -e PUID=4294967295 \
+  -e PGID=100 \
+  -e STEAM_BEE_DATA_INIT=true \
+  "$image" node dist/index.js
+docker run --rm --user 0:0 --entrypoint sh -v "$invalid_volume:/data" "$image" \
+  -c 'test "$(stat -c "%u:%g" /data/untouched)" = "0:0"'
+
+docker volume create "$guard_volume" >/dev/null
+docker run --rm --user 0:0 --entrypoint sh -v "$guard_volume:/data" "$image" \
+  -c 'mkdir -p /data/plex && touch /data/plex/sentinel && chown -R 0:0 /data' >/dev/null
+assert_unraid_init_fails \
+  "not an empty or recognized SteamBee data directory" \
+  -v "$guard_volume:/data"
+docker run --rm --user 0:0 --entrypoint sh -v "$guard_volume:/data" "$image" \
+  -c 'test "$(stat -c "%u:%g" /data)" = "0:0" && test "$(stat -c "%u:%g" /data/plex/sentinel)" = "0:0"'
+
+docker volume create "$outside_volume" >/dev/null
+docker run --rm \
+  --user 0:0 \
+  --entrypoint sh \
+  -v "$guard_volume:/data" \
+  -v "$outside_volume:/outside" \
+  "$image" \
+  -c 'find /data -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +; mkdir -p /data/.steam-bee-data-v1 /data/steam-data; touch /outside/sentinel; ln -s /outside/sentinel /data/steam-data/outside-link; chown -R 0:0 /data /outside' >/dev/null
+assert_unraid_init_fails \
+  "contains a symlink or special file" \
+  -v "$guard_volume:/data" \
+  -v "$outside_volume:/outside"
+docker run --rm \
+  --user 0:0 \
+  --entrypoint sh \
+  -v "$guard_volume:/data" \
+  -v "$outside_volume:/outside" \
+  "$image" \
+  -c 'test "$(stat -c "%u:%g" /data)" = "0:0" && test "$(stat -c "%u:%g" /outside/sentinel)" = "0:0"'
+
+docker run --rm --user 0:0 --entrypoint sh -v "$guard_volume:/fixture" "$image" \
+  -c 'find /fixture -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +; mkdir -p /fixture/data/.steam-bee-data-v1 /fixture/data/steam-data /fixture/outside; touch /fixture/outside/sentinel; ln /fixture/outside/sentinel /fixture/data/steam-data/shared; chown -R 0:0 /fixture' >/dev/null
+assert_unraid_init_fails \
+  "contains a hardlinked file" \
+  --mount "type=volume,src=$guard_volume,dst=/data,volume-subpath=data"
+docker run --rm --user 0:0 --entrypoint sh -v "$guard_volume:/fixture" "$image" \
+  -c 'test "$(stat -c "%u:%g:%h" /fixture/data/steam-data/shared)" = "0:0:2" && test "$(stat -c "%u:%g:%h" /fixture/outside/sentinel)" = "0:0:2"'
+
+docker volume create "$nest_volume" >/dev/null
+docker run --rm --user 0:0 --entrypoint sh -v "$guard_volume:/data" "$image" \
+  -c 'find /data -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +; mkdir -p /data/.steam-bee-data-v1 /data/steam-data/nested; chown -R 0:0 /data' >/dev/null
+docker run --rm --user 0:0 --entrypoint sh -v "$nest_volume:/nested" "$image" \
+  -c 'touch /nested/sentinel && chown -R 0:0 /nested' >/dev/null
+assert_unraid_init_fails \
+  "one dedicated mount without nested mounts" \
+  -v "$guard_volume:/data" \
+  -v "$nest_volume:/data/steam-data/nested"
+docker run --rm --user 0:0 --entrypoint sh -v "$nest_volume:/nested" "$image" \
+  -c 'test "$(stat -c "%u:%g" /nested/sentinel)" = "0:0"'

--- a/templates/steam-bee.xml
+++ b/templates/steam-bee.xml
@@ -22,11 +22,15 @@
   <Screenshot>https://raw.githubusercontent.com/ill-yes/steam-bee/main/docs/screenshots/steambee-sign-in.jpg</Screenshot>
   <DonateLink>https://buymeacoffee.com/ill_yes</DonateLink>
   <DonateText>Support SteamBee</DonateText>
-  <ExtraParams>--init --user=10001:10001 --pids-limit=256 --cap-drop=ALL --security-opt=no-new-privileges=true --read-only --tmpfs=/tmp:rw,noexec,nosuid,size=64m --stop-timeout=30 --log-opt=max-size=10m --log-opt=max-file=3</ExtraParams>
-  <Requires>Internet access and a persistent appdata directory writable by UID/GID 10001. Use only with Steam accounts you own. Use an HTTPS reverse proxy when exposing SteamBee beyond a trusted LAN or VPN.</Requires>
+  <ExtraParams>--entrypoint=/usr/local/bin/steam-bee-entrypoint --user=0:0 --pids-limit=256 --cap-drop=ALL --cap-add=CHOWN --cap-add=DAC_READ_SEARCH --cap-add=SETGID --cap-add=SETPCAP --cap-add=SETUID --security-opt=no-new-privileges=true --read-only --tmpfs=/tmp:rw,noexec,nosuid,nodev,size=64m --stop-timeout=30 --log-opt=max-size=10m --log-opt=max-file=3</ExtraParams>
+  <PostArgs>node dist/index.js</PostArgs>
+  <Requires>Internet access and one dedicated persistent appdata directory. The template validates and initializes appdata ownership automatically, then runs SteamBee without root privileges as PUID/PGID. Do not map the appdata parent directory. Use only with Steam accounts you own. Use an HTTPS reverse proxy when exposing SteamBee beyond a trusted LAN or VPN.</Requires>
 
   <Config Name="WebUI Port" Target="3000" Default="3000" Mode="tcp" Description="HTTP port for the SteamBee management UI." Type="Port" Display="always" Required="true" Mask="false"/>
-  <Config Name="Appdata" Target="/data" Default="/mnt/user/appdata/steambee" Mode="rw" Description="Persistent database, encrypted refresh tokens, instance secret, and Steam client data. The directory must be writable by UID/GID 10001." Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Appdata" Target="/data" Default="/mnt/user/appdata/steambee" Mode="rw" Description="Dedicated SteamBee data directory. Ownership is validated and initialized automatically for PUID/PGID; do not select the appdata parent." Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="PUID" Target="PUID" Default="99" Description="Numeric user ID used after appdata initialization. Unraid default: 99 (nobody)." Type="Variable" Display="advanced" Required="true" Mask="false"/>
+  <Config Name="PGID" Target="PGID" Default="100" Description="Numeric group ID used after appdata initialization. Unraid default: 100 (users)." Type="Variable" Display="advanced" Required="true" Mask="false"/>
+  <Config Name="Automatic Appdata Permissions" Target="STEAM_BEE_DATA_INIT" Default="true" Description="Initialize /data ownership for PUID/PGID, then permanently drop root privileges. Keep enabled on Unraid." Type="Variable" Display="advanced" Required="true" Mask="false"/>
   <Config Name="Trust Proxy" Target="TRUST_PROXY" Default="false" Description="Set to 1 for exactly one trusted reverse proxy, or provide trusted IP addresses/CIDRs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Secure Cookie" Target="COOKIE_SECURE" Default="false" Description="Set to true when SteamBee is served through HTTPS." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Log Level" Target="LOG_LEVEL" Default="info" Description="Logging level: fatal, error, warn, info, debug, trace, or silent." Type="Variable" Display="advanced" Required="false" Mask="false"/>


### PR DESCRIPTION
## Summary

- release SteamBee 1.0.5 and keep the setup-token minimum at eight characters
- add an Unraid-only PUID/PGID initialization path that adopts appdata, then permanently drops root and all capabilities
- keep the standard image and both Compose files running unchanged as UID/GID 10001
- fail closed for broad/unknown appdata mounts, nested mounts, symlinks, special files, hardlinks, invalid IDs, and unsafe root application starts
- add exact Unraid-template policy validation plus standard, migration, fresh-install, healthcheck, privilege, and negative image smoke tests
- document the one-time recreation required for already-installed Unraid templates

## Validation

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm audit --audit-level=high`
- [x] `pnpm format:check`
- [x] `pnpm check`
- [x] `pnpm test` (64 server, 22 web)
- [x] `docker compose config --quiet`
- [x] `docker compose -f compose.image.yml config --quiet`
- [x] `pnpm compose:check`
- [x] `pnpm unraid:check`
- [x] ShellCheck and sh/dash syntax checks
- [x] final ARM64 image build and full smoke test
- [x] no runtime data, secrets, or screenshots added
- [x] documentation and Docker examples updated
- [x] I have read and agree to CLA.md
