### PR TITLE
Refactor automatic Steam library imports

### DIFF
--- a/apps/server/src/steam/auto-library-importer.ts
+++ b/apps/server/src/steam/auto-library-importer.ts
@@ -1,0 +1,80 @@
+import { createLogger } from "../util/logger.js";
+import { safeErrorMessage } from "../util/redact.js";
+
+type RecordEvent = (
+  accountId: string,
+  type: string,
+  message: string,
+  metadata?: Record<string, unknown>,
+) => Promise<void>;
+
+type AutoLibraryImporterDependencies = {
+  hasLibrary: (accountId: string) => boolean | Promise<boolean>;
+  importLibrary: (accountId: string) => Promise<readonly unknown[]>;
+  metadataFor: (accountId: string) => Record<string, unknown>;
+  recordInfo: RecordEvent;
+  recordError: RecordEvent;
+};
+
+export class AutoLibraryImporter {
+  private readonly completed = new Set<string>();
+  private readonly inFlight = new Set<string>();
+  private readonly logger = createLogger("steam-auto-library-import");
+
+  constructor(private readonly dependencies: AutoLibraryImporterDependencies) {}
+
+  async import(accountId: string) {
+    if (this.completed.has(accountId) || this.inFlight.has(accountId)) return;
+
+    this.inFlight.add(accountId);
+    try {
+      if (await this.dependencies.hasLibrary(accountId)) {
+        this.completed.add(accountId);
+        this.logger.debug(
+          { accountId },
+          "Skipping auto-import because library already exists",
+        );
+        return;
+      }
+
+      await this.dependencies.recordInfo(
+        accountId,
+        "steam.library.import.start",
+        "Automatic library import started.",
+        this.metadata(accountId),
+      );
+
+      const apps = await this.dependencies.importLibrary(accountId);
+      this.completed.add(accountId);
+      await this.dependencies.recordInfo(
+        accountId,
+        "steam.library.import",
+        `${apps.length} games imported.`,
+        { ...this.metadata(accountId), appCount: apps.length },
+      );
+    } catch (error) {
+      await this.dependencies.recordError(
+        accountId,
+        "steam.library.import.error",
+        `Library import failed: ${safeErrorMessage(error)}`,
+        this.metadata(accountId),
+      );
+    } finally {
+      this.inFlight.delete(accountId);
+    }
+  }
+
+  clearAccount(accountId: string) {
+    this.completed.delete(accountId);
+    this.inFlight.delete(accountId);
+  }
+
+  clearAll() {
+    this.completed.clear();
+    this.inFlight.clear();
+  }
+
+  private metadata(accountId: string) {
+    return { ...this.dependencies.metadataFor(accountId), mode: "auto" };
+  }
+}

--- a/apps/server/src/steam/manager.ts
+++ b/apps/server/src/steam/manager.ts
@@ -1,12 +1,7 @@
 import { ACCOUNT_STATUS_CAPABILITIES, ERROR_CODES } from "@steam-bee/contracts";
 import { and, eq } from "drizzle-orm";
 import { db } from "../db/client.js";
-import {
-  boostPreset,
-  boostPresetGame,
-  steamAccount,
-  steamAccountLibrary,
-} from "../db/schema.js";
+import { boostPreset, boostPresetGame, steamAccount } from "../db/schema.js";
 import {
   broadcast,
   recordErrorEventSafely,
@@ -16,7 +11,7 @@ import { createLogger, errorLogFields } from "../util/logger.js";
 import { safeErrorMessage } from "../util/redact.js";
 import { appError } from "../http/errors.js";
 import type { OperationContext } from "../operation-context.js";
-import { replaceSelectedGames } from "./repository.js";
+import { hasAccountLibrary, replaceSelectedGames } from "./repository.js";
 import { enforceGameLimit } from "./validation.js";
 import { SteamWorker } from "./worker.js";
 import { getAccountOrThrow } from "./account-repository.js";
@@ -26,17 +21,28 @@ import { AccountOperationState } from "./account-operation-state.js";
 import type { WorkerStatusPayload } from "./types.js";
 import { ScheduleCoordinator } from "./schedule-coordinator.js";
 import { scheduleRepository } from "./schedule-repository.js";
+import { AutoLibraryImporter } from "./auto-library-importer.js";
 
 class SteamManager {
   private workers = new Map<string, SteamWorker>();
-  private autoImportInFlight = new Set<string>();
-  private autoImportDone = new Set<string>();
   private shutdownPromise: Promise<void> | null = null;
   private readonly logger = createLogger("steam-manager");
   private readonly accountOperations = new AccountOperationState();
   private readonly statusEventRecorder = new SteamStatusEventRecorder(
     (accountId) => this.accountOperations.metadata(accountId),
   );
+  private readonly autoLibraryImporter = new AutoLibraryImporter({
+    hasLibrary: hasAccountLibrary,
+    importLibrary: async (accountId) => {
+      const worker = await this.getWorkerForAccount(accountId);
+      return worker.importLibrary();
+    },
+    metadataFor: (accountId) => this.accountOperations.metadata(accountId),
+    recordInfo: (accountId, type, message, metadata) =>
+      this.recordInfo(accountId, type, message, metadata),
+    recordError: (accountId, type, message, metadata) =>
+      this.recordError(accountId, type, message, metadata),
+  });
   private readonly scheduleCoordinator = new ScheduleCoordinator({
     repository: scheduleRepository,
     runForAccount: (accountId, operation) =>
@@ -379,8 +385,7 @@ class SteamManager {
     );
     this.accountOperations.clearContexts();
     this.statusEventRecorder.clearAll();
-    this.autoImportInFlight.clear();
-    this.autoImportDone.clear();
+    this.autoLibraryImporter.clearAll();
     this.scheduleCoordinator.clearAll();
   }
 
@@ -458,73 +463,14 @@ class SteamManager {
       !payload.error &&
       ACCOUNT_STATUS_CAPABILITIES[payload.status].importable
     ) {
-      await this.autoImportLibrary(accountId);
-    }
-  }
-
-  private async autoImportLibrary(accountId: string) {
-    if (
-      this.autoImportDone.has(accountId) ||
-      this.autoImportInFlight.has(accountId)
-    ) {
-      return;
-    }
-
-    this.autoImportInFlight.add(accountId);
-
-    try {
-      const existingLibraryEntry = await db
-        .select({ appId: steamAccountLibrary.appId })
-        .from(steamAccountLibrary)
-        .where(eq(steamAccountLibrary.accountId, accountId))
-        .limit(1);
-
-      if (existingLibraryEntry.length > 0) {
-        this.autoImportDone.add(accountId);
-        this.logger.debug(
-          { accountId },
-          "Skipping auto-import because library already exists",
-        );
-        return;
-      }
-
-      await this.recordInfo(
-        accountId,
-        "steam.library.import.start",
-        "Automatic library import started.",
-        { ...this.accountOperations.metadata(accountId), mode: "auto" },
-      );
-
-      const worker = await this.getWorkerForAccount(accountId);
-      const apps = await worker.importLibrary();
-      this.autoImportDone.add(accountId);
-      await this.recordInfo(
-        accountId,
-        "steam.library.import",
-        `${apps.length} games imported.`,
-        {
-          ...this.accountOperations.metadata(accountId),
-          appCount: apps.length,
-          mode: "auto",
-        },
-      );
-    } catch (error) {
-      await this.recordError(
-        accountId,
-        "steam.library.import.error",
-        `Library import failed: ${safeErrorMessage(error)}`,
-        { ...this.accountOperations.metadata(accountId), mode: "auto" },
-      );
-    } finally {
-      this.autoImportInFlight.delete(accountId);
+      await this.autoLibraryImporter.import(accountId);
     }
   }
 
   private clearAccountState(accountId: string) {
     this.accountOperations.clearContext(accountId);
     this.statusEventRecorder.clearAccount(accountId);
-    this.autoImportInFlight.delete(accountId);
-    this.autoImportDone.delete(accountId);
+    this.autoLibraryImporter.clearAccount(accountId);
     this.scheduleCoordinator.clearAccount(accountId);
   }
 

--- a/apps/server/src/steam/repository.ts
+++ b/apps/server/src/steam/repository.ts
@@ -189,6 +189,16 @@ export function replaceAccountLibrary(
   replace();
 }
 
+export function hasAccountLibrary(accountId: string) {
+  return Boolean(
+    sqlite
+      .prepare(
+        "SELECT 1 FROM steam_account_library WHERE account_id = ? LIMIT 1",
+      )
+      .get(accountId),
+  );
+}
+
 function insertPresetGames(presetId: string, appIds: number[], now: number) {
   const insert = sqlite.prepare(`
     INSERT INTO boost_preset_game (preset_id, app_id, created_at)

--- a/apps/server/tests/auto-library-importer.test.ts
+++ b/apps/server/tests/auto-library-importer.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { AutoLibraryImporter } from "../src/steam/auto-library-importer.js";
+
+function createImporter(
+  overrides: Partial<ConstructorParameters<typeof AutoLibraryImporter>[0]> = {},
+) {
+  const dependencies = {
+    hasLibrary: vi.fn().mockResolvedValue(false),
+    importLibrary: vi.fn().mockResolvedValue([{ appId: 10 }, { appId: 20 }]),
+    metadataFor: vi.fn().mockReturnValue({ correlationId: "operation-1" }),
+    recordInfo: vi.fn().mockResolvedValue(undefined),
+    recordError: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  return { importer: new AutoLibraryImporter(dependencies), dependencies };
+}
+
+describe("AutoLibraryImporter", () => {
+  it("imports an empty library once and records its lifecycle", async () => {
+    const { importer, dependencies } = createImporter();
+
+    await importer.import("account-1");
+    await importer.import("account-1");
+
+    expect(dependencies.hasLibrary).toHaveBeenCalledTimes(1);
+    expect(dependencies.importLibrary).toHaveBeenCalledTimes(1);
+    expect(dependencies.recordInfo).toHaveBeenNthCalledWith(
+      1,
+      "account-1",
+      "steam.library.import.start",
+      "Automatic library import started.",
+      { correlationId: "operation-1", mode: "auto" },
+    );
+    expect(dependencies.recordInfo).toHaveBeenNthCalledWith(
+      2,
+      "account-1",
+      "steam.library.import",
+      "2 games imported.",
+      { correlationId: "operation-1", mode: "auto", appCount: 2 },
+    );
+  });
+
+  it("marks an existing library complete without importing it", async () => {
+    const { importer, dependencies } = createImporter({
+      hasLibrary: vi.fn().mockResolvedValue(true),
+    });
+
+    await importer.import("account-1");
+    await importer.import("account-1");
+
+    expect(dependencies.hasLibrary).toHaveBeenCalledTimes(1);
+    expect(dependencies.importLibrary).not.toHaveBeenCalled();
+    expect(dependencies.recordInfo).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates concurrent import requests", async () => {
+    let finishImport: (apps: readonly unknown[]) => void = () => {};
+    const importLibrary = vi.fn(
+      () =>
+        new Promise<readonly unknown[]>((resolve) => {
+          finishImport = resolve;
+        }),
+    );
+    const { importer, dependencies } = createImporter({ importLibrary });
+
+    const first = importer.import("account-1");
+    await vi.waitFor(() => expect(importLibrary).toHaveBeenCalledTimes(1));
+    const duplicate = importer.import("account-1");
+    finishImport([]);
+    await Promise.all([first, duplicate]);
+
+    expect(dependencies.hasLibrary).toHaveBeenCalledTimes(1);
+    expect(importLibrary).toHaveBeenCalledTimes(1);
+  });
+
+  it("records failures and permits a later retry", async () => {
+    const importLibrary = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce([]);
+    const { importer, dependencies } = createImporter({ importLibrary });
+
+    await importer.import("account-1");
+    await importer.import("account-1");
+
+    expect(importLibrary).toHaveBeenCalledTimes(2);
+    expect(dependencies.recordError).toHaveBeenCalledWith(
+      "account-1",
+      "steam.library.import.error",
+      "Library import failed: temporary failure",
+      { correlationId: "operation-1", mode: "auto" },
+    );
+  });
+
+  it("can clear completed state when an account is forgotten", async () => {
+    const { importer, dependencies } = createImporter();
+
+    await importer.import("account-1");
+    importer.clearAccount("account-1");
+    await importer.import("account-1");
+
+    expect(dependencies.importLibrary).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/server/tests/repository.test.ts
+++ b/apps/server/tests/repository.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { migrate, sqlite } from "../src/db/client.js";
 import {
   createPresetRecord,
+  hasAccountLibrary,
   replaceAccountLibrary,
   replaceSelectedGames,
 } from "../src/steam/repository.js";
@@ -83,6 +84,16 @@ describe("Steam repository transactions", () => {
         )
         .all(accountId),
     ).toEqual([{ appId: 440, favorite: 1, tagsJson: '["classic"]' }]);
+  });
+
+  it("detects whether an account already has an imported library", () => {
+    expect(hasAccountLibrary(accountId)).toBe(true);
+
+    sqlite
+      .prepare("DELETE FROM steam_account_library WHERE account_id = ?")
+      .run(accountId);
+
+    expect(hasAccountLibrary(accountId)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What changed

- extract automatic Steam library imports from `SteamManager` into an injectable `AutoLibraryImporter`
- centralize the existing-library lookup in the Steam repository
- preserve import deduplication, lifecycle events, retry behavior, and account cleanup
- add focused tests for existing libraries, concurrent requests, retries, cleanup, and repository detection

## Why

`SteamManager` previously owned worker orchestration, database access, import lifecycle state, event recording, and error handling for automatic library imports. Moving that workflow into a dedicated service reduces the manager's responsibilities and makes the concurrency and retry behavior directly testable.

There is no user-facing behavior change.

## Validation

- `pnpm format:check`
- `pnpm audit --audit-level high`
- `pnpm check`
- `pnpm test` (184 tests)
- `docker compose -f compose.yml config`
- `docker compose -f compose.image.yml config`
- `pnpm compose:check`
- `pnpm unraid:check`
- `git diff --check`
